### PR TITLE
Replay Buffer Upgrades

### DIFF
--- a/pyrl/replay_buffer.py
+++ b/pyrl/replay_buffer.py
@@ -26,6 +26,7 @@ class ReplayBuffer:
         spec = {
             "obs": {"dtype": np.float32, "shape": self.obs_flat.after_dim},
             "act": {"dtype": np.float32, "shape": self.act_flat.after_dim},
+            "index": {"dtype": np.int64, "shape": 1},
             "next_obs": {"dtype": np.float32, "shape": self.obs_flat.after_dim},
             "rew": {"dtype": np.float32, "shape": 1},
             "done": {"dtype": np.float32, "shape": 1},
@@ -37,13 +38,14 @@ class ReplayBuffer:
 
     @staticmethod
     def from_env(env: Env, **kwargs) -> ReplayBuffer:
-        return ReplayBuffer(env.observation_space, env.action_space)
+        return ReplayBuffer(env.observation_space, env.action_space, **kwargs)
 
     def __len__(self):
         return len(self.buffer)
 
-    def add(self, batch: dict):
+    def add(self, batch: dict) -> None:
         self.buffer.add(
+            index=self.buffer.get_next_index() + np.arange(batch["rew"].shape[1]),
             **untorchify(
                 {
                     "obs": self.obs_flat(batch["obs"]),
@@ -52,18 +54,21 @@ class ReplayBuffer:
                     "rew": batch["rew"],
                     "done": batch["done"],
                 }
-            )
+            ),
         )
 
-    def sample(self, batch_size=None):
+    def sample(self, batch_size=None, with_index=False) -> dict:
         if not batch_size:
             batch_size = self.batch_size
 
-        batch = torchify(self.buffer.sample(batch_size), self.device)
-        return {
+        batch: dict = torchify(self.buffer.sample(batch_size), self.device)
+        result = {
             "obs": self.obs_unflat(batch["obs"]),
             "act": self.act_unflat(batch["act"]),
             "next_obs": self.obs_unflat(batch["next_obs"]),
             "rew": batch["rew"],
             "done": batch["done"],
         }
+        if with_index:
+            result["index"] = batch["index"]
+        return result

--- a/pyrl/replay_buffer.py
+++ b/pyrl/replay_buffer.py
@@ -45,6 +45,8 @@ class ReplayBuffer:
 
     def add(self, batch: dict) -> None:
         self.buffer.add(
+            # HACK: Add in the indices since cpprb doesn't have
+            # sample_with_indices function
             index=self.buffer.get_next_index() + np.arange(batch["rew"].shape[1]),
             **untorchify(
                 {

--- a/pyrl/utils/torchify.py
+++ b/pyrl/utils/torchify.py
@@ -1,12 +1,11 @@
 from typing import Union
 import torch
-import numbers
 import numpy as np
 
-untorchified = Union[np.ndarray, dict]
-torchified = Union[torch.Tensor, dict]
 
-def torchify(obs: untorchified, device: Union[str, torch.device] = "cpu") -> torchified:
+def torchify(
+    obs: Union[np.ndarray, dict], device: Union[str, torch.device] = "cpu"
+) -> Union[torch.Tensor, dict]:
     if isinstance(obs, dict):
         ret = {}
         for k, v in obs.items():
@@ -22,7 +21,7 @@ def torchify(obs: untorchified, device: Union[str, torch.device] = "cpu") -> tor
     return obs.to(device)
 
 
-def untorchify(obs: torchified) -> untorchified:
+def untorchify(obs: Union[torch.Tensor, dict]) -> Union[np.ndarray, dict]:
     if isinstance(obs, dict):
         return {k: untorchify(v) for k, v in obs.items()}
     obs = obs.detach().cpu()

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs, pkg }:
+{ pkgs, pkg, pythonpaths ? [""] }:
 pkgs.mkShell {
   buildInputs = with pkgs; [
     nodePackages.pyright
@@ -13,4 +13,7 @@ pkgs.mkShell {
       tensorflow-tensorboard_2
     ]))
   ];
+  shellHook = ''
+    export PYTHONPATH=${pkgs.lib.concatStringsSep ":" (map (s: "$PWD/${s}") pythonpaths)}
+  '';
 }

--- a/test/test_replay_buffer.py
+++ b/test/test_replay_buffer.py
@@ -1,6 +1,7 @@
 from pyrl.utils import create_random_space, torchify
 from pyrl.replay_buffer import ReplayBuffer
 from flatten_dict import flatten
+from gym.spaces import Discrete
 import torch
 
 
@@ -30,3 +31,18 @@ def test_integration():
             assert torch.all(step[k].cpu() == step2[k].cpu())
 
         print(buf.log_epoch())
+
+
+def test_indices():
+    BATCH_SIZE = 1000
+    STEP_SIZE = 100
+
+    space = Discrete(BATCH_SIZE)
+    buf = ReplayBuffer(space, space, BATCH_SIZE, BATCH_SIZE, "cpu")
+    r = torch.arange(BATCH_SIZE)
+    for i in range(0, BATCH_SIZE, STEP_SIZE):
+        mb = r[i*BATCH_SIZE:(i+1)*BATCH_SIZE].reshape(1, -1)
+        buf.add({"obs": mb, "act": mb, "rew": mb, "next_obs": mb, "done": torch.zeros_like(mb)})
+    for _ in range(STEP_SIZE):
+        sample = buf.sample(BATCH_SIZE, True)
+        assert torch.all(sample["obs"] == sample["index"])


### PR DESCRIPTION
- Added `with_index` option to ReplayBuffer.sample
- Added more tests
- Changed shell.nix to support `PYTHONPATH` for development ease
- Although the code takes a bit more memory it's easier than having to make a pull request to cpprb